### PR TITLE
Correct Issue#8: Item has already been added.

### DIFF
--- a/GetGraphUserStatisticsReport.PS1
+++ b/GetGraphUserStatisticsReport.PS1
@@ -77,7 +77,7 @@ $NextLink = $SignInData.'@Odata.NextLink'
 # If we have a next link, go and process the remaining set of users
 While ($NextLink -ne $Null) { 
    Write-Host "Still processing..."
-   $SignInData = Invoke-WebRequest -Method GET -Uri $NextLink -ContentType "application/json" -Headers $Headers
+   $SignInData = Invoke-WebRequest -Method GET -Uri $NextLink -ContentType "application/json" -Headers $Headers -UseBasicParsing
    $SignInData = $SignInData | ConvertFrom-JSon
    ForEach ($U in $SignInData.Value) {  
    If ($U.UserType -eq "Member") {


### PR DESCRIPTION
Add -UseBasicParsing parameter to Invoke-WebRequest command to correct the thrown error if Internet Explorer's first launch configuration hasn't been completed yet; Is added to the first but missed off this second Invoke-WebRequest call.