### PR TITLE
Update FindAccountsWithForwarding.PS1

### DIFF
--- a/FindAccountsWithForwarding.PS1
+++ b/FindAccountsWithForwarding.PS1
@@ -23,10 +23,11 @@ ForEach ($M in $Mbx) {
             "Mailbox type"    = $M.RecipientTypeDetails
             ForwardingAddress = $M.ForwardingSmtpAddress.Split(":")[1]
             InboxRule         = "N/A" 
-            "Rule Removed"    = "N/A" }
+            "Rule Removed"    = "N/A" 
+            Enabled           = "N/A"}
        $Report.Add($ReportLine)
     } 
-    $InboxRules = (Get-InboxRule -Mailbox $M.Alias | ? {$_.ForwardTo -or $_.ForwardAsAttachmentTo })
+    $InboxRules = (Get-InboxRule -Mailbox $M.Alias | ? {$_.ForwardTo -or $_.ForwardAsAttachmentTo -or $_.RedirectTo})
     If ($InboxRules -ne $Null) {
        Write-Host "Processing inbox rules"
        ForEach ($Rule in $InboxRules) {
@@ -34,6 +35,7 @@ ForEach ($M in $Mbx) {
           $ForwardTo = @()
           $ForwardTo = ($Rule.ForwardTo | ? { ($_ -Match "SMTP") -or ($_ -Match "EX:") } )
           $ForwardTo += ($Rule.ForwardAsAttachmentTo | ? {($_ -Match "SMTP") -or ($_ -Match "EX:")})
+          $ForwardTo += ($Rule.RedirectTo | ? {($_ -Match "SMTP") -or ($_ -Match "EX:")})
           If ($ForwardTo.Count -gt 0) {
              ForEach ($Recipient in $ForwardTo) {
                 If ($Recipient -Match "EX:") {
@@ -60,7 +62,8 @@ ForEach ($M in $Mbx) {
                 "Mailbox type"    = $M.RecipientTypeDetails
                 ForwardingAddress = $EmailAddress
                 InboxRule         = $Rule.Name 
-                "Rule Removed"    = $RuleRemoved }
+                "Rule Removed"    = $RuleRemoved 
+                Enabled           = $Rule.Enabled}
              $Report.Add($ReportLine) }
        }
      }


### PR DESCRIPTION
Added check for redirectto rule and gathering of whether a rule is enabled.

I was testing and found this missed redirect to rules, plus it was finding rules that weren't actually enabled, so I've added that to the report line properties. 

I might suggest commenting out the remove-inboxrule command - I missed it when I first scanned the script and was slightly surprised when it did actually remove a rule in place... (note to self, read script more thoroughly next time... :) )