### PR TITLE
Update FindTeamChannelsWithWiki.PS1

### DIFF
--- a/FindTeamChannelsWithWiki.PS1
+++ b/FindTeamChannelsWithWiki.PS1
@@ -35,7 +35,7 @@ ForEach ($Team in $Teams) {
               $True     { 
                  # Get Team owners 
                  [array]$OwnerData = Get-MgGroupOwner -GroupId $Team.Id
-                 $TeamOwners = $OwnerData.AdditionalProperties.displayName -Join ", "
+                 $TeamOwners = $OwnerData.AdditionalProperties.displayName -Join "|"
                  $WikiCheck = "Wiki content exists"}
               $False    { $WikiCheck = "No content" }
               Default    { $WikiCheck = "No content" }
@@ -59,7 +59,7 @@ ForEach ($Team in $Teams) {
 
 $WikiReport = $Report | Where-Object {$_.AppId -eq "com.microsoft.teamspace.tab.wiki" -and $_.Check -eq "Wiki content exists"}
 $WikiReport | Out-GridView
-$WikiReport | Export-CSV -NoTypeInformation WikisToReview.CSV
+$WikiReport | Export-CSV -NoTypeInformation WikisToReview.CSV -Encoding UTF8 -Delimiter ";"
 Write-Host ("All done. {0} Teams processed. The Wiki tab with content was found in {1} channels. CSV file generated in WikisToReview.csv" -f $Teams.count, $WikiReport.count)
 
 # An example script used to illustrate a concept. More information about the topic can be found in the Office 365 for IT Pros eBook https://gum.co/O365IT/


### PR DESCRIPTION
Minor improvements 
- in-field separator different from csv-separator (ln 38), 
- csv-file utf8 encoded and csv-delimiter to semi-colon (ln 62)

**Line 38:**
The in-field delimiter should be something different from the csv-delimiter and an often used character in the display name of users:
e.g. Peter Smith and Paul Black are often referenced with display names "Black, Paul" and "Smith, Peter" which leads to a owners field value in the script's output of "Smith, Peter, Black, Paul". There was simple solution to separate owners in MS PowerQuery to individual rows/fields by the "," delimiter. Therefore I changed the delimiter to "|".

**Line 62:**
The default csv-delimiter "," lead to false records when loading the csv into columns in excel as the team names haven't got stringed in ""s and a comma is a valid character in a team name. Therefore changed this to ";" and included UTF8 encoding for all the special characters in European languages.