### PR TITLE
Update UpdateOffice365PowerShellModules.PS1

### DIFF
--- a/UpdateOffice365PowerShellModules.PS1
+++ b/UpdateOffice365PowerShellModules.PS1
@@ -27,7 +27,9 @@ ForEach ($Module in $O365Modules) {
    $CurrentModule = Find-Module -Name $Module
    If ($CurrentModule) {
      $CurrentVersion = $CurrentModule.Version
-     $CurrentVersion = $CurrentVersion.Major.toString() + "." + $CurrentVersion.Minor.toString() + "." + $CurrentVersion.Build.toString()
+      If ($CurrentVersion -isnot [string]) {
+        $CurrentVersion = $CurrentVersion.Major.toString() + "." + $CurrentVersion.Minor.toString() + "." + $CurrentVersion.Build.toString()
+      }
      [datetime]$CurrentModuleDate = $CurrentModule.PublishedDate
      Write-Host ("Current version of the {0} module in the PowerShell Gallery is {1}" -f $Module, $CurrentVersion)
    }
@@ -43,7 +45,9 @@ ForEach ($Module in $O365Modules) {
 
    If ($PCModule) {
       $PCVersion = $PCModule.Version
-      $PCVersion = $PCVersion.Major.toString() + "." + $PCVersion.Minor.toString() + "." + $PCVersion.Build.toString()
+      If ($PCVersion -isnot [string]) {
+         $PCVersion = $PCVersion.Major.toString() + "." + $PCVersion.Minor.toString() + "." + $PCVersion.Build.toString()
+      }
       [datetime]$PCModuleDate = $PCModule.PublishedDate
 
       If ($PCModuleDate -eq $CurrentModuleDate) { 


### PR DESCRIPTION
Adding a check to make sure the variable is not already a string. When in PowerShell 7, the $CurrentVersion is already a string and not an object like in PowerShell 5.1 and doesn't need to be converted. This results in an error.