### PR TITLE
Replaced AuditOwner parameter value

### DIFF
--- a/Report-MailboxAuditingConfiguration.PS1
+++ b/Report-MailboxAuditingConfiguration.PS1
@@ -18,7 +18,7 @@ Write-Host ("{0} mailboxes found" -f $Mbx.Count)
 [array]$DefaultAuditSet = "Admin", "Delegate", "Owner"
 [string]$DefaultAuditSetReport = $DefaultAuditSet -join ", "
 # Define the auditable actions that we want to check for
-[array]$CriticalAuditActionsOwner = "MailItemsAccessed", "Send", "searchqueryinitiatedexchange"
+[array]$CriticalAuditActionsOwner = "MailItemsAccessed", "Send", "SearchQueryInitiated"
 [array]$CriticalAuditActionsDelegate = "SendAs", "SendOnBehalf", "MoveToDeletedItems", `
     "SoftDelete", "HardDelete", "MailItemsAccessed"
 


### PR DESCRIPTION
fixes #120
Replaced AuditOwner parameter value:
- old value: `searchqueryinitiatedexchange`
- new value: `SearchQueryInitiated`

see also:
[Get started with auditing solutions > Step 4: Enable SearchQueryInitiated events](https://learn.microsoft.com/en-us/purview/audit-get-started#step-4-enable-searchqueryinitiated-events)
