### PR TITLE
Update ReportActiveTeams.ps1

### DIFF
--- a/ReportActiveTeams.ps1
+++ b/ReportActiveTeams.ps1
@@ -45,7 +45,7 @@ ForEach ($T in $Teams) {
 
   If ($ChatsPerDay -gt 0 -and $ChatsPerDay -le 2) { $ActiveStatus = "Moderate" }
   Elseif ($ChatsPerDay -gt 2 -and $ChatsPerDay -le 5) { $ActiveStatus = "Reasonable"}
-  Elseif ($ChatPerDay -gt 5) { $ActiveStatus = "Heavy" }   
+  Elseif ($ChatsPerDay -gt 5) { $ActiveStatus = "Heavy" }   
  
   $ReportLine = [PSCustomObject]@{
      Alias        = $T.Alias


### PR DESCRIPTION
There is a typo in the script: $ChatPerDay instead of $ChatsPerDay in the last condition, which prevents the 'Heavy' status from ever being assigned.