### PR TITLE
Update Copy-GroupsFromOneUsertoAnother.PS1

### DIFF
--- a/Copy-GroupsFromOneUsertoAnother.PS1
+++ b/Copy-GroupsFromOneUsertoAnother.PS1
@@ -208,7 +208,7 @@ ForEach ($GroupId in $GroupsToProcess) {
             }
             $Report.Add($ReportLine)
             If ($RemoveOriginalUser) {
-                $Outcome = Remove-UserFromM365Group -UserId $SourceUser.Id -GroupId $Group.Id -GroupName
+                $Outcome = Remove-UserFromM365Group -UserId $SourceUser.Id -GroupId $Group.Id -GroupName $GroupDisplayName
                 Write-Host $Outcome -ForegroundColor Yellow
             }
         } Catch {


### PR DESCRIPTION
Missing variable from call to Remove-UserFromM365Group. Note: this has been identified because it was different to the other calls to the Remove-* functions rather than a detailed review.